### PR TITLE
Raise error if geojson file cannot be found

### DIFF
--- a/clioguesser_backend/core/management/commands/populate_cliopatria.py
+++ b/clioguesser_backend/core/management/commands/populate_cliopatria.py
@@ -18,10 +18,7 @@ class Command(BaseCommand):
         # Ensure the file exists
         cliopatria_geojson_path = options["geojson_file"]
         if not os.path.exists(cliopatria_geojson_path):
-            self.stdout.write(
-                self.style.ERROR(f"File {cliopatria_geojson_path} does not exist")
-            )
-            return
+            raise RuntimeError(f"File {cliopatria_geojson_path} does not exist")
         # Skip if already populated
         if Cliopatria.objects.exists():
             self.stdout.write(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,8 @@ services:
     networks:
       - clioguesser-net
     command: >
-      sh -c "python3 manage.py migrate &&
+      sh -c "sleep 2 &&
+             python3 manage.py migrate &&
              python3 manage.py populate_cliopatria data/cliopatria_polities_only.geojson &&
              python3 manage.py runserver 0.0.0.0:8000"
 


### PR DESCRIPTION
Changes:

1. Loudly raise an error if the geojson file cannot be found.
2. Give the db a couple of seconds to warm up.